### PR TITLE
Resolve traybin files from module directory

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -96,7 +96,7 @@ const getTrayBinPath = async (debug: boolean = false, copyDir: boolean | string 
     darwin: `tray_darwin${debug ? '' : '_release'}`,
     linux: `tray_linux${debug ? '' : '_release'}`
   })[process.platform]
-  const binPath = path.resolve(`./traybin/${binName}`)
+  const binPath = path.resolve(`${__dirname}/traybin/${binName}`)
   if (copyDir) {
     copyDir = path.join((
       typeof copyDir === 'string'


### PR DESCRIPTION
Resolving the traybin files from "." will mean that they are being searched inside the directory that uses systray2.
This means one would have to setup a symlink to `node_modules/systray2/traybin" in order to get it working.
Resolving from "__dirname" means that the file is being searched inside the systray2 module folder which should be what we want here.